### PR TITLE
SES options via mail headers

### DIFF
--- a/lib/mail/ses/options_builder.rb
+++ b/lib/mail/ses/options_builder.rb
@@ -22,7 +22,7 @@ module Mail
 
       # Returns the options for Aws::SESV2::Client#send_email.
       def build
-        message_options.merge(ses_options)
+        message_options.merge(ses_options, ses_options_from_message)
       end
 
       private
@@ -30,6 +30,17 @@ module Mail
       def ses_options
         # TODO: address fields should be encoded to UTF-8
         slice_hash(@options, *SES_FIELDS)
+      end
+
+      def ses_options_from_message
+        mail_options = @message[:mail_options]&.unparsed_value
+
+        if mail_options
+          @message[:mail_options] = nil
+          slice_hash(mail_options, *SES_FIELDS)
+        else
+          {}
+        end
       end
 
       def message_options

--- a/spec/options_builder_spec.rb
+++ b/spec/options_builder_spec.rb
@@ -102,6 +102,42 @@ RSpec.describe Mail::SES::OptionsBuilder do
       it { expect(subject).to eq(exp) }
     end
 
+    context "with options on the mail object" do
+      let(:mail) do
+        Mail.new do
+          from '"My From" <from@abc.com>'
+          reply_to ["reply-to1@def.com", "", "My Reply-To <rt@qqq.com>"]
+          to ["to1@def.com", "My To <to2@xyz.com>", ""]
+          cc ["", "cc1@xyz.com", "My CC <cc2@def.com>"]
+          bcc ["My BCC <bcc1@abc.com>", "", "bcc2@def.com"]
+          body "This is the body"
+          headers(mail_options: {email_tags: [{name: "Foo", value: "Bar"}]})
+        end
+      end
+
+      let(:exp) do
+        {
+          from_email_address: "My From <from@abc.com>",
+          reply_to_addresses: ["reply-to1@def.com", "My Reply-To <rt@qqq.com>"],
+          destination: {
+            to_addresses: ["to1@def.com", "My To <to2@xyz.com>"],
+            cc_addresses: ["cc1@xyz.com", "My CC <cc2@def.com>"],
+            bcc_addresses: ["My BCC <bcc1@abc.com>", "bcc2@def.com"]
+          },
+          email_tags: [
+            {name: "Foo", value: "Bar"}
+          ],
+          content: {
+            raw: {
+              data: "Fixed message body"
+            }
+          }
+        }
+      end
+
+      it { expect(subject).to eq(exp) }
+    end
+
     context "when addresses contain non-ascii chars" do
       let(:mail) do
         Mail.new do


### PR DESCRIPTION
This makes it possible to set new options (like `email_tags`) for each individual email message.